### PR TITLE
prototype: reusing an open telemetry instrumentation module

### DIFF
--- a/instrumentation-otel/opentelemetry-instrumentation-sequelize.js
+++ b/instrumentation-otel/opentelemetry-instrumentation-sequelize.js
@@ -1,0 +1,68 @@
+const opentelemetryApi = require("@opentelemetry/api");
+const { SequelizeInstrumentation } = require('opentelemetry-instrumentation-sequelize');
+
+// delegate TraceProvider -- will return a custom tracer that
+// uses the agent APIs to create spans
+//
+// Implements every (i.e. a single) method of the trace provider API
+// https://github.com/open-telemetry/opentelemetry-js-api/blob/3ccf157fe06616acb1530a561370b00c1a62101b/src/trace/tracer_provider.ts#L22
+
+class DelegateTraceProvider {
+  constructor(agent) {
+    this.agent = agent
+  }
+
+  // TODO: we inherit name and version from the interface, but this
+  //       prototype doesn't use them
+  getTracer(name, version) {
+
+    return new DelegateTracer(this.agent)
+  }
+}
+
+// delegate tracer -- starts our spans (full tracer API not implemented)
+// TODO: eventually this would need to implement every method of the
+//       OpenTelemetry tracer interface
+//       https://github.com/open-telemetry/opentelemetry-js-api/blob/3ccf157fe06616acb1530a561370b00c1a62101b/src/trace/tracer.ts#L24
+class DelegateTracer {
+  constructor(agent) {
+    this.agent = agent
+  }
+
+  startSpan(name, attributes) {
+    console.log('startSpan')
+    const span = this.agent.startSpan(name)
+    return new DelegateSpan(span)
+  }
+}
+
+// delegate span -- wraps our spans incase the oTel span model
+// and the elastic span model end up differing.
+//
+// TODO: this would eventually need to be expanded out to implement every
+//       method of the open telementry span interface.
+//       https://github.com/open-telemetry/opentelemetry-js-api/blob/3ccf157fe06616acb1530a561370b00c1a62101b/src/trace/span.ts#L32
+
+class DelegateSpan {
+  constructor(span) {
+    this.span = span
+  }
+
+  end() {
+    console.log('end span')
+    this.span.end()
+  }
+}
+
+function init(agent) {
+  // the creation of the delegate trace provider
+  // TODO: should probably be moved out of this
+  // individual instrumentation file and started
+  // elsewhere.
+  const dtp = new DelegateTraceProvider(agent)
+  opentelemetryApi.trace.getTracerProvider().setDelegate(dtp)
+
+  // create the instrumentation
+  return new SequelizeInstrumentation
+}
+module.exports = {init}

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -465,7 +465,6 @@ Agent.prototype.captureError = function (err, opts, cb) {
 
       if (agent._transport) {
         agent.logger.info('Sending error to Elastic APM: %o', { id })
-        console.log(apmError)
         agent._transport.sendError(apmError, function () {
           agent.flush(function (flushErr) {
             if (cb) {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -465,6 +465,7 @@ Agent.prototype.captureError = function (err, opts, cb) {
 
       if (agent._transport) {
         agent.logger.info('Sending error to Elastic APM: %o', { id })
+        console.log(apmError)
         agent._transport.sendError(apmError, function () {
           agent.flush(function (flushErr) {
             if (cb) {

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -84,6 +84,10 @@ function Instrumentation (agent) {
       return require(`./modules/${pathName}.js`)(...args)
     })
   }
+
+  // load otel instrumentations
+  const {init} = require('../instrumentation-otel/opentelemetry-instrumentation-sequelize')
+  init(this._agent)
 }
 
 Object.defineProperty(Instrumentation.prototype, 'ids', {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "monitor-event-loop-delay": "^1.0.0",
     "object-filter-sequence": "^1.0.0",
     "object-identity-map": "^1.0.2",
+    "opentelemetry-instrumentation-sequelize": "^0.24.0",
     "original-url": "^1.2.3",
     "pino": "^6.11.2",
     "read-pkg-up": "^7.0.1",


### PR DESCRIPTION
This PR is a prototype for reusing an open telemetry instrumentation module in the Node.js Agent.  

At a high level, to reuse these instrumentation, we need to 

1. Create and register a delegate trace provider
2. Create and register a delegate tracer for starting spans
3. Create a delegate span object that wraps our elastic-spans
4. Instantiate the Instrumentation Class

Since we're starting spans with the agent APIs, our current context handling should be sufficient to handle this. 

Possible cons here include

1. These instrumentation classes are not covered by any of the OpenTelementry GA backwards compatibility guarantees -- we may be signing up for a lot of upkeep if these classes change how they work (or go away completely).  We'd probably want to hard-pin the opentelemtry dependencies

2. Unknown perf. implications -- the base OpenTelemetry instrumentation classes do a bunch of extra work to register metrics handlers (and other work). We'd probably want to feature/config flag this feature as experimental and do load testing. 

Next steps: 
- Move the trace provider out of the individual instrumentation
- Test with a few more open telemetry instrumentation modules
- fully implement the interfaces for our delegate objects
- test assumptions about span context handling